### PR TITLE
Add LoadingPopup for API request progress indication

### DIFF
--- a/BufeApp.csproj
+++ b/BufeApp.csproj
@@ -70,6 +70,9 @@
 	  <MauiXaml Update="Controls\AnimatedSvgIcon.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Controls\LoadingPopup.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Pages\LoginPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/Controls/LoadingPopup.xaml
+++ b/Controls/LoadingPopup.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             x:Class="BufeApp.Controls.LoadingPopup"
+             CanBeDismissedByTappingOutsideOfPopup="False"
+             Color="Transparent">
+    <Grid BackgroundColor="#80000000">
+        <ActivityIndicator IsRunning="True" Color="{StaticResource Primary}" HorizontalOptions="Center" VerticalOptions="Center"/>
+    </Grid>
+</toolkit:Popup>

--- a/Controls/LoadingPopup.xaml.cs
+++ b/Controls/LoadingPopup.xaml.cs
@@ -1,0 +1,15 @@
+using CommunityToolkit.Maui.Views;
+using Microsoft.Maui.Devices;
+
+namespace BufeApp.Controls
+{
+    public partial class LoadingPopup : Popup
+    {
+        public LoadingPopup()
+        {
+            InitializeComponent();
+            var mainDisplayInfo = DeviceDisplay.MainDisplayInfo;
+            Size = new Size(mainDisplayInfo.Width / mainDisplayInfo.Density, mainDisplayInfo.Height / mainDisplayInfo.Density);
+        }
+    }
+}

--- a/Services/ApiService.cs
+++ b/Services/ApiService.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using BufeApp.Controls;
+using CommunityToolkit.Maui.Views;
 
 namespace BufeApp.Services
 {
@@ -15,6 +17,37 @@ namespace BufeApp.Services
         public static string LogoutEndpoint = "account/logout";
         public static string CategoriesEndpoint = "categories";
 
+        private static LoadingPopup _loadingPopup;
+        private static int _loadingCounter = 0;
+
+        private static void ShowLoading()
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                _loadingCounter++;
+                if (_loadingPopup != null) return;
+                _loadingPopup = new LoadingPopup();
+                Application.Current?.MainPage?.ShowPopup(_loadingPopup);
+            });
+        }
+
+        private static void HideLoading()
+        {
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                _loadingCounter--;
+                if (_loadingCounter <= 0)
+                {
+                    _loadingCounter = 0;
+                    if (_loadingPopup != null)
+                    {
+                        _loadingPopup.Close();
+                        _loadingPopup = null;
+                    }
+                }
+            });
+        }
+
         private static JsonSerializerOptions GetJsonOptions()
         {
             return new JsonSerializerOptions
@@ -25,36 +58,52 @@ namespace BufeApp.Services
 
         public static async Task<T> GetAsync<T>(string endpoint, string bearerToken = null)
         {
-            var client = new HttpClient();
-            client.BaseAddress = new Uri(BaseUrl);
-            client.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-            if (!string.IsNullOrEmpty(bearerToken))
+            try
             {
-                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearerToken);
+                ShowLoading();
+                var client = new HttpClient();
+                client.BaseAddress = new Uri(BaseUrl);
+                client.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+                if (!string.IsNullOrEmpty(bearerToken))
+                {
+                    client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearerToken);
+                }
+                var response = await client.GetAsync(endpoint);
+                if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized) { UserService.UserUnauthorised(); }
+                response.EnsureSuccessStatusCode();
+                var jsonResponse = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<T>(jsonResponse, GetJsonOptions());
             }
-            var response = await client.GetAsync(endpoint);
-            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized) { UserService.UserUnauthorised(); }
-            response.EnsureSuccessStatusCode();
-            var jsonResponse = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<T>(jsonResponse, GetJsonOptions());
+            finally
+            {
+                HideLoading();
+            }
         }
 
         public static async Task<TResponse> PostAsync<TRequest, TResponse>(string endpoint, TRequest data, string bearerToken = null)
         {
-            var client = new HttpClient();
-            client.BaseAddress = new Uri(BaseUrl);
-            client.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-            if (!string.IsNullOrEmpty(bearerToken))
+            try
             {
-                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearerToken);
+                ShowLoading();
+                var client = new HttpClient();
+                client.BaseAddress = new Uri(BaseUrl);
+                client.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+                if (!string.IsNullOrEmpty(bearerToken))
+                {
+                    client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", bearerToken);
+                }
+                var jsonData = JsonSerializer.Serialize(data);
+                var content = new StringContent(jsonData, Encoding.UTF8, "application/json");
+                var response = await client.PostAsync(endpoint, content);
+                if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized) { UserService.UserUnauthorised(); }
+                response.EnsureSuccessStatusCode();
+                var jsonResponse = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<TResponse>(jsonResponse, GetJsonOptions());
             }
-            var jsonData = JsonSerializer.Serialize(data);
-            var content = new StringContent(jsonData, Encoding.UTF8, "application/json");
-            var response = await client.PostAsync(endpoint, content);
-            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized) { UserService.UserUnauthorised(); }
-            response.EnsureSuccessStatusCode();
-            var jsonResponse = await response.Content.ReadAsStringAsync();
-            return JsonSerializer.Deserialize<TResponse>(jsonResponse, GetJsonOptions());
+            finally
+            {
+                HideLoading();
+            }
         }
     }
 }


### PR DESCRIPTION
Introduced a reusable LoadingPopup control to display a loading indicator during API requests. Integrated the popup into ApiService to show/hide it automatically for GetAsync and PostAsync calls, with support for concurrent requests. Updated project file to include the new control.