### PR TITLE
Add search/filter for categories and items on MainPage

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -73,6 +73,7 @@
                         <Entry Grid.Column="1" Placeholder="Craving a burger? Search menu..." 
                            PlaceholderColor="{AppThemeBinding Light={StaticResource TextSecLight}, Dark={StaticResource TextSecDark}}"
                            TextColor="{AppThemeBinding Light={StaticResource TextMainLight}, Dark={StaticResource TextMainDark}}"
+                           Text="{Binding SearchQuery}"
                            VerticalOptions="Center" BackgroundColor="Transparent" />
                     </Grid>
                 </Border>

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -203,6 +203,18 @@ namespace BufeApp
         [ObservableProperty]
         private ObservableCollection<CategorieResponseModel> categories;
 
+        // Store original data for filtering
+        private List<CategorieResponseModel> _allCategories = new();
+        private Dictionary<int, List<ItemModel>> _originalCategoryItems = new();
+
+        [ObservableProperty]
+        private string searchQuery = string.Empty;
+
+        partial void OnSearchQueryChanged(string value)
+        {
+            FilterCategories();
+        }
+
         [ObservableProperty]
         private CategorieResponseModel? selectedCategory;
 
@@ -240,11 +252,16 @@ namespace BufeApp
                     ApiService.CategoriesEndpoint, 
                     UserService.BearerToken);
 
+                _allCategories = categoriesResult;
+                _originalCategoryItems.Clear();
                 Categories.Clear();
                 FeaturedItems.Clear();
 
                 foreach (var category in categoriesResult)
                 {
+                    // Cache original items for filtering
+                    _originalCategoryItems[category.Id] = category.Items.ToList();
+                    
                     Categories.Add(category);
 
                     // Collect featured items from all categories
@@ -267,6 +284,51 @@ namespace BufeApp
             finally
             {
                 IsBusy = false;
+            }
+        }
+
+        private void FilterCategories()
+        {
+            if (_allCategories == null || !_allCategories.Any())
+                return;
+
+            if (string.IsNullOrWhiteSpace(SearchQuery))
+            {
+                // Restore all categories and items
+                Categories.Clear();
+                foreach (var category in _allCategories)
+                {
+                    if (_originalCategoryItems.TryGetValue(category.Id, out var originalItems))
+                    {
+                        category.Items = originalItems;
+                    }
+                    Categories.Add(category);
+                }
+                return;
+            }
+
+            var lowerQuery = SearchQuery.ToLowerInvariant();
+            Categories.Clear();
+
+            foreach (var category in _allCategories)
+            {
+                if (!_originalCategoryItems.TryGetValue(category.Id, out var originalItems))
+                    continue;
+
+                // Determine if category name matches
+                bool categoryMatches = category.Name.ToLowerInvariant().Contains(lowerQuery);
+
+                // Filter items
+                var matchingItems = originalItems.Where(i => 
+                    i.Name.ToLowerInvariant().Contains(lowerQuery) || 
+                    (i.Description != null && i.Description.ToLowerInvariant().Contains(lowerQuery))).ToList();
+
+                if (matchingItems.Any() || categoryMatches)
+                {
+                    // If category name matches, should we show all items or just matching? Let's show matching, or all if none matches
+                    category.Items = matchingItems.Any() ? matchingItems : originalItems;
+                    Categories.Add(category);
+                }
             }
         }
 

--- a/Models/CategorieResponseModel.cs
+++ b/Models/CategorieResponseModel.cs
@@ -9,6 +9,7 @@ namespace BufeApp.Models
     public class CategorieResponseModel : INotifyPropertyChanged
     {
         private bool _isSelected;
+        private List<ItemModel> _items = new List<ItemModel>();
 
         [JsonPropertyName("id")]
         public int Id { get; set; }
@@ -23,7 +24,18 @@ namespace BufeApp.Models
         public DateTime UpdatedAt { get; set; }
 
         [JsonPropertyName("items")]
-        public List<ItemModel> Items { get; set; } = new List<ItemModel>();
+        public List<ItemModel> Items
+        {
+            get => _items;
+            set
+            {
+                if (_items != value)
+                {
+                    _items = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
 
         [JsonIgnore]
         public bool IsSelected


### PR DESCRIPTION
Introduced SearchQuery binding and filtering logic to allow users to search menu categories and items by name or description. Original data is cached for restoring results. Updated CategorieResponseModel.Items to notify UI on changes.